### PR TITLE
Test runner utility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "c2-chacha"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cast"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,6 +597,11 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,11 +618,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -701,6 +743,7 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ignore 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zip 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -938,6 +981,7 @@ dependencies = [
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bzip2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b"
 "checksum bzip2-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6584aa36f5ad4c9247f5323b0a42f37802b37a836f0ad87084d7a33961abe25f"
+"checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 "checksum cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
 "checksum cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)" = "0213d356d3c4ea2c18c40b037c3be23cd639825c18f25ee670ac7813beeef99c"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
@@ -991,9 +1035,13 @@ dependencies = [
 "checksum pin-project-lite 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4f1f61fedcfa3b402e157c23e235b1ab6c30d52c219492c63504059e2bdd3408"
 "checksum pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
 "checksum podio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd"
+"checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+"checksum rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae1b169243eaf61759b8475a998f0a385e42042370f3a7dbaf35246eacc8412"
+"checksum rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
 "checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+"checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 "checksum rand_os 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a788ae3edb696cfcba1c19bfd388cc4b8c21f8a408432b199c072825084da58a"
 "checksum rand_xoshiro 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0e18c91676f670f6f0312764c759405f13afb98d5d73819840cf72a518487bff"
 "checksum rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "83a27732a533a1be0a0035a111fe76db89ad312f6f0347004c220c57f209a123"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ async-std = "1"
 [dev-dependencies]
 sha2 = "0.8.0"
 criterion = "0.3"
+rand = "0.7"
 
 [[bench]]
 name = "parsing"

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -48,15 +48,15 @@ fn random_name() -> String {
     let mut rng = thread_rng();
     iter::repeat(())
             .map(|()| rng.sample(Alphanumeric))
-            .take(7)
+            .take(25)
             .collect::<String>()
 }
 
 fn delete_temp_dir(folder_name: &str){
-    let path = PathBuf::from(format!("./temp/{}", folder_name));
+    let path = PathBuf::from(format!("tests/temp/{}", folder_name));
     let result = remove_dir_all(&path);
     
-    println!("Deleting files... {:?} - {:?}", path, result);
+    println!("Cleaning up tests... {:?} - {:?}", path, result);
 
     match result {
         Err(ref e) if e.kind() == NotFound => {},

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -1,0 +1,84 @@
+use std::fs::{remove_dir_all, create_dir_all};
+use std::path::PathBuf;
+use std::io::ErrorKind::NotFound;
+
+pub mod tests {
+    pub struct TestCleaner<S = Box<dyn Fn(&str) -> ()>, T = Box<dyn Fn(&str) -> ()>>
+        where S: Fn(&str) -> (),
+              T: Fn(&str) -> ()
+    {
+        setup: S,
+        teardown: T,
+    }
+
+    impl TestCleaner {
+        pub fn new<S: 'static, T: 'static>(setup: S, teardown: T) -> Self
+            where S: Fn(&str) -> (),
+                  T: Fn(&str) -> ()
+        {
+            TestCleaner { 
+                setup: Box::new(setup),
+                teardown: Box::new(teardown),
+            }
+        }
+
+        pub fn run<R>(&self, test: R)  
+            where R: FnOnce(&str) -> () + std::panic::UnwindSafe
+        {
+            let folder_name = super::random_name();
+
+            (self.setup)(folder_name.as_ref());
+
+            let result = std::panic::catch_unwind(|| {
+                test(folder_name.as_ref())
+            });
+
+            (self.teardown)(folder_name.as_ref());
+
+            result.unwrap();
+        }
+    }
+}
+
+fn random_name() -> String {
+    use std::iter;
+    use rand::{Rng, thread_rng};
+    use rand::distributions::Alphanumeric;
+     
+    let mut rng = thread_rng();
+    iter::repeat(())
+            .map(|()| rng.sample(Alphanumeric))
+            .take(7)
+            .collect::<String>()
+}
+
+fn delete_temp_dir(folder_name: &str){
+    let path = PathBuf::from(format!("./temp/{}", folder_name));
+    let result = remove_dir_all(&path);
+    
+    println!("Deleting files... {:?} - {:?}", path, result);
+
+    match result {
+        Err(ref e) if e.kind() == NotFound => {},
+        Err(ref e) if e.kind() != NotFound => result.unwrap(),
+        _ => {},
+    }
+}
+
+pub fn build_basic_runner() -> tests::TestCleaner {
+    tests::TestCleaner::new(|folder_name| {
+        delete_temp_dir(folder_name);
+        create_dir_all(format!("./temp/{}", folder_name)).unwrap();
+    }, |folder_name| {
+        delete_temp_dir(folder_name);
+    })
+}
+
+/*#[test]
+fn test_test_unitilities() {
+    let runner = build_basic_runner();
+
+    runner.run(|_folder_name| {
+        panic!();
+    })
+}*/

--- a/tests/unzip_file.rs
+++ b/tests/unzip_file.rs
@@ -1,7 +1,5 @@
 use std::fs::File;
 use std::{io, path::Path};
-use async_std::task;
-
 use sha2::{digest::Digest, Sha256};
 
 use rzip::unzip_archive;
@@ -14,53 +12,51 @@ use test_utils::build_basic_runner;
 fn test_unzip() {
     let runner = build_basic_runner();
 
-    runner.run(|folder_name| {
-        task::block_on(async {
-            let _ = unzip_archive(
-                File::open("tests/dummy_files/zip_10MB.zip").expect("The dummy zip file was not found"),
-                Path::new(&format!("tests/temp/{}", folder_name)),
-            )
-            .await;
+    runner.run(move |folder_name| Box::new(async move {
+        let _ = unzip_archive(
+            File::open("tests/dummy_files/zip_10MB.zip").expect("The dummy zip file was not found"),
+            Path::new(&format!("tests/temp/{}", folder_name)),
+        )
+        .await;
 
-            let files = vec![
-                (
-                    format!("tests/temp/{}/zip_10MB/file-example_PDF_1MB.pdf", folder_name),
-                    "5E4D40FCD8B22453A5DA2D32533B128F2565F3FC7A4D1647A93C86CDBB4BE37A",
-                ),
-                (
-                    format!("tests/temp/{}/zip_10MB/file_example_JPG_1MB.jpg", folder_name),
-                    "683A8528125CA09D8314435C051331DE2B4C981C756721A2D12C103E8603A1D2",
-                ),
-                (
-                    format!("tests/temp/{}/zip_10MB/file_example_ODS_5000.ods", folder_name),
-                    "2DD8CA392783A86AFC0B0120B333C7FF83BB5FCFB1A0088BE6D5957E05DA1C91",
-                ),
-                (
-                    format!("tests/temp/{}/zip_10MB/file_example_PNG_2500kB.jpg", folder_name),
-                    "7AB84F2D1A5806C3A0BCE9BC67FEDA52F55423950656C50B7C07733CEB6F956A",
-                ),
-                (
-                    format!("tests/temp/{}/zip_10MB/file_example_PPT_1MB.ppt", folder_name),
-                    "B709DEBB365A5437F2472F350745ED2F8A6890D7CB3D81E6750F2D5DD44625C9",
-                ),
-                (
-                    format!("tests/temp/{}/zip_10MB/file_example_TIFF_10MB.tiff", folder_name),
-                    "7D931EB0A8B51EDC594A255739785C6B297D081B27A91BF942B6475BC322596D",
-                ),
-                (
-                    format!("tests/temp/{}/zip_10MB/file-sample_1MB.doc", folder_name),
-                    "C560136E2A2B7036523F69EFDB4E9CDF369ABE167BA3A095E26D74E261774B20",
-                ),
-            ];
+        let files = vec![
+            (
+                format!("tests/temp/{}/zip_10MB/file-example_PDF_1MB.pdf", folder_name),
+                "5E4D40FCD8B22453A5DA2D32533B128F2565F3FC7A4D1647A93C86CDBB4BE37A",
+            ),
+            (
+                format!("tests/temp/{}/zip_10MB/file_example_JPG_1MB.jpg", folder_name),
+                "683A8528125CA09D8314435C051331DE2B4C981C756721A2D12C103E8603A1D2",
+            ),
+            (
+                format!("tests/temp/{}/zip_10MB/file_example_ODS_5000.ods", folder_name),
+                "2DD8CA392783A86AFC0B0120B333C7FF83BB5FCFB1A0088BE6D5957E05DA1C91",
+            ),
+            (
+                format!("tests/temp/{}/zip_10MB/file_example_PNG_2500kB.jpg", folder_name),
+                "7AB84F2D1A5806C3A0BCE9BC67FEDA52F55423950656C50B7C07733CEB6F956A",
+            ),
+            (
+                format!("tests/temp/{}/zip_10MB/file_example_PPT_1MB.ppt", folder_name),
+                "B709DEBB365A5437F2472F350745ED2F8A6890D7CB3D81E6750F2D5DD44625C9",
+            ),
+            (
+                format!("tests/temp/{}/zip_10MB/file_example_TIFF_10MB.tiff", folder_name),
+                "7D931EB0A8B51EDC594A255739785C6B297D081B27A91BF942B6475BC322596D",
+            ),
+            (
+                format!("tests/temp/{}/zip_10MB/file-sample_1MB.doc", folder_name),
+                "C560136E2A2B7036523F69EFDB4E9CDF369ABE167BA3A095E26D74E261774B20",
+            ),
+        ];
 
-            for (file_name, expected_hash) in files {
-                let hash = hash_file(&file_name)
-                    .await
-                    .unwrap_or_else(|_| panic!("Couldn't hash file {}", file_name));
-                assert_eq!(expected_hash, hash);
-            }
-        });
-    });
+        for (file_name, expected_hash) in files {
+            let hash = hash_file(&file_name)
+                .await
+                .unwrap_or_else(|_| panic!("Couldn't hash file {}", file_name));
+            assert_eq!(expected_hash, hash);
+        }
+    }));
 
 }
 

--- a/tests/unzip_file.rs
+++ b/tests/unzip_file.rs
@@ -12,7 +12,7 @@ use test_utils::build_basic_runner;
 fn test_unzip() {
     let runner = build_basic_runner();
 
-    runner.run(move |folder_name| Box::new(async move {
+    runner.run(|folder_name| Box::new(async move {
         let _ = unzip_archive(
             File::open("tests/dummy_files/zip_10MB.zip").expect("The dummy zip file was not found"),
             Path::new(&format!("tests/temp/{}", folder_name)),

--- a/tests/unzip_file.rs
+++ b/tests/unzip_file.rs
@@ -1,4 +1,4 @@
-use std::fs::{remove_dir_all, File};
+use std::fs::File;
 use std::{io, path::Path};
 use async_std::task;
 
@@ -6,60 +6,68 @@ use sha2::{digest::Digest, Sha256};
 
 use rzip::unzip_archive;
 
+mod test_utils;
+
+use test_utils::build_basic_runner;
+
 #[test]
 fn test_unzip() {
-    task::block_on(async {
-        let _ = unzip_archive(
-            File::open("tests/dummy_files/zip_10MB.zip").expect("The dummy zip file was not found"),
-            Path::new("tests/temp"),
-        )
-        .await;
+    let runner = build_basic_runner();
 
-        let files = vec![
-            (
-                "tests/temp/zip_10MB/file-example_PDF_1MB.pdf",
-                "5E4D40FCD8B22453A5DA2D32533B128F2565F3FC7A4D1647A93C86CDBB4BE37A",
-            ),
-            (
-                "tests/temp/zip_10MB/file_example_JPG_1MB.jpg",
-                "683A8528125CA09D8314435C051331DE2B4C981C756721A2D12C103E8603A1D2",
-            ),
-            (
-                "tests/temp/zip_10MB/file_example_ODS_5000.ods",
-                "2DD8CA392783A86AFC0B0120B333C7FF83BB5FCFB1A0088BE6D5957E05DA1C91",
-            ),
-            (
-                "tests/temp/zip_10MB/file_example_PNG_2500kB.jpg",
-                "7AB84F2D1A5806C3A0BCE9BC67FEDA52F55423950656C50B7C07733CEB6F956A",
-            ),
-            (
-                "tests/temp/zip_10MB/file_example_PPT_1MB.ppt",
-                "B709DEBB365A5437F2472F350745ED2F8A6890D7CB3D81E6750F2D5DD44625C9",
-            ),
-            (
-                "tests/temp/zip_10MB/file_example_TIFF_10MB.tiff",
-                "7D931EB0A8B51EDC594A255739785C6B297D081B27A91BF942B6475BC322596D",
-            ),
-            (
-                "tests/temp/zip_10MB/file-sample_1MB.doc",
-                "C560136E2A2B7036523F69EFDB4E9CDF369ABE167BA3A095E26D74E261774B20",
-            ),
-        ];
+    runner.run(|folder_name| {
+        task::block_on(async {
+            let _ = unzip_archive(
+                File::open("tests/dummy_files/zip_10MB.zip").expect("The dummy zip file was not found"),
+                Path::new(&format!("tests/temp/{}", folder_name)),
+            )
+            .await;
 
-        for (file_name, expected_hash) in files {
-            let hash = hash_file(file_name)
-                .await
-                .unwrap_or_else(|_| panic!("Couldn't hash file {}", file_name));
-            assert_eq!(expected_hash, hash);
-        }
+            let files = vec![
+                (
+                    format!("tests/temp/{}/zip_10MB/file-example_PDF_1MB.pdf", folder_name),
+                    "5E4D40FCD8B22453A5DA2D32533B128F2565F3FC7A4D1647A93C86CDBB4BE37A",
+                ),
+                (
+                    format!("tests/temp/{}/zip_10MB/file_example_JPG_1MB.jpg", folder_name),
+                    "683A8528125CA09D8314435C051331DE2B4C981C756721A2D12C103E8603A1D2",
+                ),
+                (
+                    format!("tests/temp/{}/zip_10MB/file_example_ODS_5000.ods", folder_name),
+                    "2DD8CA392783A86AFC0B0120B333C7FF83BB5FCFB1A0088BE6D5957E05DA1C91",
+                ),
+                (
+                    format!("tests/temp/{}/zip_10MB/file_example_PNG_2500kB.jpg", folder_name),
+                    "7AB84F2D1A5806C3A0BCE9BC67FEDA52F55423950656C50B7C07733CEB6F956A",
+                ),
+                (
+                    format!("tests/temp/{}/zip_10MB/file_example_PPT_1MB.ppt", folder_name),
+                    "B709DEBB365A5437F2472F350745ED2F8A6890D7CB3D81E6750F2D5DD44625C9",
+                ),
+                (
+                    format!("tests/temp/{}/zip_10MB/file_example_TIFF_10MB.tiff", folder_name),
+                    "7D931EB0A8B51EDC594A255739785C6B297D081B27A91BF942B6475BC322596D",
+                ),
+                (
+                    format!("tests/temp/{}/zip_10MB/file-sample_1MB.doc", folder_name),
+                    "C560136E2A2B7036523F69EFDB4E9CDF369ABE167BA3A095E26D74E261774B20",
+                ),
+            ];
 
-        remove_dir_all("tests/temp/zip_10MB").expect("The unzipped directory couldn't be deleted");
-    })
+            for (file_name, expected_hash) in files {
+                let hash = hash_file(&file_name)
+                    .await
+                    .unwrap_or_else(|_| panic!("Couldn't hash file {}", file_name));
+                assert_eq!(expected_hash, hash);
+            }
+        });
+    });
+
 }
 
 async fn hash_file(file: &str) -> Result<String, io::Error> {
     let mut file = File::open(file)?;
     let mut hasher = Sha256::new();
-    let _ = io::copy(&mut file, &mut hasher);
+    io::copy(&mut file, &mut hasher).unwrap();
+    drop(file);
     Ok(format!("{:X}", hasher.result()))
 }


### PR DESCRIPTION
After experimenting a bit I found a way to keep the test directories clean, even if the old one died.

Basically, it creates a random named directory inside of tests and clean it up after the test, regardless of if it fails or succeeds. 

The only limitation I found is that there are not yet async lambdas in rust, only code blocks. Therefore, I cannot automate the async stuff. You can check the test we have to see how it looks.

